### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/cwrucutter/Classifiers.png?label=ready&title=Ready)](https://waffle.io/cwrucutter/Classifiers)
 # Classifiers
 A ROS package that contains classifiers such as Neural Networks, Filters, etc.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/cwrucutter/Classifiers

This was requested by a real person (user aew61) on waffle.io, we're not trying to spam you.
